### PR TITLE
Fix bad Ore Crusher recipes

### DIFF
--- a/src/main/java/me/waleks/simplematerialgenerators/SMGItemSetup.java
+++ b/src/main/java/me/waleks/simplematerialgenerators/SMGItemSetup.java
@@ -51,7 +51,8 @@ public final class SMGItemSetup {
                 SMGItems.SMG_GENERATOR_COBBLESTONE, null, null,
                 null, null, null,
                 null, null, null
-            }).register(plugin);
+            })
+            .register(plugin);
 
         new MaterialGenerator(
             SMGItems.SMG_ITEM_CATEGORY,
@@ -73,7 +74,8 @@ public final class SMGItemSetup {
                 SMGItems.SMG_GENERATOR_STONE, null, null,
                 null, null, null,
                 null, null, null
-            }).register(plugin);
+            })
+            .register(plugin);
 
         new MaterialGenerator(
             SMGItems.SMG_ITEM_CATEGORY,
@@ -96,7 +98,8 @@ public final class SMGItemSetup {
                 SMGItems.SMG_GENERATOR_COBBLESTONE, null, null,
                 null, null, null,
                 null, null, null
-            }).register(plugin);
+            })
+            .register(plugin);
 
         new MaterialGenerator(
             SMGItems.SMG_ITEM_CATEGORY,
@@ -118,7 +121,8 @@ public final class SMGItemSetup {
                 SMGItems.SMG_GENERATOR_GRAVEL, null, null,
                 null, null, null,
                 null, null, null
-            }).register(plugin);
+            })
+            .register(plugin);
 
         new MaterialGenerator(
             SMGItems.SMG_ITEM_CATEGORY,
@@ -170,13 +174,25 @@ public final class SMGItemSetup {
 
         new BrokenGenerator(
             SMGItems.SMG_ITEM_CATEGORY,
-                SMGItems.SMG_GENERATOR_REDSTONE_BROKEN,
-                RecipeType.ORE_CRUSHER,
+                SMGItems.SMG_GENERATOR_REDSTONE_BADLY_FORMED,
+                RecipeType.ENHANCED_CRAFTING_TABLE,
                 new ItemStack[] {
                     SMGItems.SMG_GENERATOR_SAND, null, SMGItems.SMG_GENERATOR_GRAVEL,
                     null, null, null,
                     null, null, null
-                }).register(plugin);
+                })
+            .register(plugin);
+
+        new BrokenGenerator(
+            SMGItems.SMG_ITEM_CATEGORY,
+                SMGItems.SMG_GENERATOR_REDSTONE_BROKEN,
+                RecipeType.ORE_CRUSHER,
+                new ItemStack[] {
+                    SMGItems.SMG_GENERATOR_REDSTONE_BADLY_FORMED, null, null,
+                    null, null, null,
+                    null, null, null
+                })
+            .register(plugin);
 
         new MaterialGenerator(
             SMGItems.SMG_ITEM_CATEGORY,
@@ -192,13 +208,25 @@ public final class SMGItemSetup {
 
         new BrokenGenerator(
             SMGItems.SMG_ITEM_CATEGORY,
-            SMGItems.SMG_GENERATOR_OBSIDIAN_BROKEN,
-            RecipeType.ORE_CRUSHER,
+            SMGItems.SMG_GENERATOR_OBSIDIAN_BADLY_FORMED,
+            RecipeType.ENHANCED_CRAFTING_TABLE,
             new ItemStack[] {
                 SMGItems.SMG_GENERATOR_COBBLESTONE, null, SMGItems.SMG_GENERATOR_STONE,
                 null, SlimefunItems.COBALT_PICKAXE, null,
                 SMGItems.SMG_GENERATOR_SMOOTH_STONE, null, SMGItems.SMG_GENERATOR_NETHERRACK
-            }).register(plugin);
+            })
+            .register(plugin);
+
+        new BrokenGenerator(
+            SMGItems.SMG_ITEM_CATEGORY,
+            SMGItems.SMG_GENERATOR_OBSIDIAN_BROKEN,
+            RecipeType.ORE_CRUSHER,
+            new ItemStack[] {
+                SMGItems.SMG_GENERATOR_OBSIDIAN_BADLY_FORMED, null, null,
+                null, null, null,
+                null, null, null
+            })
+            .register(plugin);
 
         new MaterialGenerator(
             SMGItems.SMG_ITEM_CATEGORY,

--- a/src/main/java/me/waleks/simplematerialgenerators/SMGItems.java
+++ b/src/main/java/me/waleks/simplematerialgenerators/SMGItems.java
@@ -145,6 +145,15 @@ public final class SMGItems {
         "&9&oSimpleMaterialGenerators"
     );
 
+    public static final SlimefunItemStack SMG_GENERATOR_REDSTONE_BADLY_FORMED = new SlimefunItemStack(
+            "SMG_GENERATOR_REDSTONE_BADLY_FORMED",
+            Material.REDSTONE_BLOCK,
+            "&cRedstone generator &8(Badly Formed)",
+            "&8Needs to be reformed",
+            "",
+            "&9&oSimpleMaterialGenerators"
+    );
+
     public static final SlimefunItemStack SMG_GENERATOR_REDSTONE_BROKEN = new SlimefunItemStack(
             "SMG_GENERATOR_REDSTONE_BROKEN",
             Material.REDSTONE_BLOCK,
@@ -159,6 +168,15 @@ public final class SMGItems {
             Material.REDSTONE_BLOCK,
             "&cRedstone generator",
             "&6Rate: &e24 ticks",
+            "",
+            "&9&oSimpleMaterialGenerators"
+    );
+
+    public static final SlimefunItemStack SMG_GENERATOR_OBSIDIAN_BADLY_FORMED = new SlimefunItemStack(
+            "SMG_GENERATOR_OBSIDIAN_BADLY_FORMED",
+            Material.OBSIDIAN,
+            "&5Obsidian generator &8(Badly Formed)",
+            "&8Needs to be reformed",
             "",
             "&9&oSimpleMaterialGenerators"
     );


### PR DESCRIPTION
Fixes #5 

Ore crushers can only have single item recipes so I have added another step to the crafting process so we can retain the recipes while making sure only a single item is put through the crusher.